### PR TITLE
0.17.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "csgo-discord-scrimbot"
-version = "0.16.1"
+version = "0.17.0"
 authors = ["MartinWienc <32913968+MartinWienc@users.noreply.github.com>"]
 edition = "2018"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,9 +158,10 @@ impl FromStr for Command {
     type Err = ();
     fn from_str(input: &str) -> Result<Command, Self::Err> {
         match input {
-            ".join" => Ok(Command::JOIN),
+            _ if ".join".starts_with(input) => Ok(Command::JOIN),
             ".leave" => Ok(Command::LEAVE),
             ".list" => Ok(Command::LIST),
+            _ if ".queue".starts_with(input) => Ok(Command::LIST),
             ".start" => Ok(Command::START),
             ".steamid" => Ok(Command::STEAMID),
             ".maps" => Ok(Command::MAPS),
@@ -171,7 +172,8 @@ impl FromStr for Command {
             ".cancel" => Ok(Command::CANCEL),
             ".captain" => Ok(Command::CAPTAIN),
             ".pick" => Ok(Command::PICK),
-            ".ready" => Ok(Command::READY),
+            _ if ".ready".starts_with(input) => Ok(Command::READY),
+            ".gaben" => Ok(Command::READY),
             ".unready" => Ok(Command::UNREADY),
             ".ct" => Ok(Command::CT),
             ".t" => Ok(Command::T),
@@ -179,7 +181,7 @@ impl FromStr for Command {
             ".removemap" => Ok(Command::REMOVEMAP),
             ".recoverqueue" => Ok(Command::RECOVERQUEUE),
             ".clear" => Ok(Command::CLEAR),
-            ".help" => Ok(Command::HELP),
+            _ if ".help".starts_with(input) => Ok(Command::HELP),
             _ => Err(()),
         }
     }


### PR DESCRIPTION
- added logic so `.join`, `.ready`, `.help` can be matched as long as it starts with the preceding characters
- added `.queue` as an alias of `.list`